### PR TITLE
Cm 1894 improve mci handling

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,13 +1,20 @@
 unreleased changes
 -------------------
 * Support for "published" or "external" MCIs. right_st will attempt to check for
-  and use MultiCloudImages from the MultiCloud Marketplace if they exist.
+  and use MultiCloudImages from the MultiCloud Marketplace if they exist ([#10])
+* Support for full definition of MCIs in the ServerTemplate YAML file, including
+  managing MCI settings and tags ([#11])
+
+[#10]: https://github.com/rightscale/right_st/issues/10
+[#11]: https://github.com/rightscale/right_st/issues/11
 
 v1.2.0 / 2016-06-05
 -------------------
 * Add ability to use "published" aka "external" RightScripts. These are
   RightScripts published in the MultiCloud Marketplace. These are linked to
   instead of downloaded to disk ([#16])
+
+[#16]: https://github.com/rightscale/right_st/issues/16
 
 v1.1.0 / 2016-04-15
 -------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+unreleased changes
+-------------------
+* Support for "published" or "external" MCIs. right_st will attempt to check for
+  and use MultiCloudImages from the MultiCloud Marketplace if they exist.
+
 v1.2.0 / 2016-06-05
 -------------------
 * Add ability to use "published" aka "external" RightScripts. These are

--- a/README.md
+++ b/README.md
@@ -134,10 +134,11 @@ A MultiCloudImage definition allows you to specify an MCI four different ways by
     * 'Name' - String - Name of the MCI
     * 'Tags' - Array of Strings - Representing tags on the MCI. Typically 'rs_agent:type=right_link_lite' will be required.
     * 'Description' - String - Optional description for the MCI
-    * 'Settings' - Array of Settings - A setting represents the following API resource: [MultiCloudImageSettings](http://reference.rightscale.com/api1.5/resources/ResourceMultiCloudImageSettings.html). Each Setting must have the following keys:
-        * `Cloud` - String - Name of cloud
-        * `Image` - String - resource_uid of image
-        * `Instance Type` - String - Name of instance type.
+    * 'Settings' - Array of Settings - A setting represents the following API resource: [MultiCloudImageSettings](http://reference.rightscale.com/api1.5/resources/ResourceMultiCloudImageSettings.html). The following keys are used:
+        * `Cloud` - String - Required - Name of cloud
+        * `Image` - String - Required - resource_uid of image
+        * `Instance Type` - String - Required - Name of instance type.
+        * `User Data` - String - Optional - User Data template for this cloud/image combination.
 
 An Alert definition consists of three fields: a Name, Definition, and Clause (all strings). Clause is a text description of the Alert with this exact format: `If <Metric>.<ValueType> <ComparisonOperator> <Threshold> for <Duration> minutes Then <Action> <ActionValue>`:
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ ServerTemplates are defined by a YAML format representing the ServerTemplate. Th
 | Description | String | Description field for the ServerTemplate. |
 | RightScripts | Hash of String -> Array of RightScripts| The hash key is the sequence type, one of "Boot", "Operational", or "Decommission". The hash value is a array of RightScripts. Each RightScript can be specified in one of two ways, as a locally managed RightScript and a "published" or "external" RightScript. A locally managed RightScript is specified as a pathname to a file on disk. Published RightScripts are links to RightScripts shared in the MultiCloud marketplace and consist of a hash specifying a Name/Revision/Publisher to look up.|
 | Inputs | Hash of String -> String | The hash key is the input name. The hash value is the default value. Note this inputs array is much simpler than the Input definition in RightScripts - only default values can be overridden in a ServerTemplate. |
-| MultiCloudImages | Array of MultiCloudImages | An array of MultiCloudImage definitions. A MultiCloudImage definition is a hash of fields taking a few different formats.See section below for further details. |
+| MultiCloudImages | Array of MultiCloudImages | An array of MultiCloudImage definitions. A MultiCloudImage definition is a hash of fields taking a few different formats. See section below for further details. |
 | Alerts | Array of Alerts | An array of Alert definitions, defined below. |
 
-A MultiCloudImage definition allows you to specify an MCI four different ways by supplying different hash keys. The first three combinations specified below allow you to use pre-existing MCIs. The fourth one allows you to fully manage an MCI in your local account:
+A MultiCloudImage definition allows you to specify an MCI in four different ways by supplying different hash keys. The first three combinations specified below allow you to use pre-existing MCIs. The fourth one allows you to fully manage an MCI in your local account:
 
 1. 'Name' and 'Revision' and 'Publisher': Name/Revision/Publisher of MCI available in the MultiCloud Marketplace. The MCI will be automatically imported into the account if it's not already there. Preferred.
 2. 'Name' and 'Revision'.: Name/Revision of MCI in your local account. It will not attempt to be autoimported from the MultiCloud Marketplace.
@@ -181,7 +181,7 @@ MultiCloudImages:
 # Format 4: Fully Managed MCI object specifying all clouds/images:
 - Name: MyUbuntu_14.04_x64
 - Description: My companies custom MCI
-- Tags
+- Tags:
   - rs_agent:type=right_link_lite
   - rs_agent:mime_shellscript=https://rightlink.rightscale.com/rll/10/rightlink.boot.sh
 - Settings:

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ right_st st download <name|href|id> [<path>]
     -p, --published: When downloading RightScripts, first check if it's published in
                      the MultiCloud marketplace and insert a link to the published
                      script if so.
-    -i, --images: When specifying MultiCloudImages, use Format 4. This fully specifies
-                  all cloud/image/instance type combinations to completely manage the
-                  MultiCloudImage in the YAML.
+    -m, --mci-settings: When specifying MultiCloudImages, use Format 4. This fully specifies
+                        all cloud/image/instance type settings combinations to completely
+                        manage the MultiCloudImage in the YAML.
 
 right_st st validate <path>...
   Validate a ServerTemplate YAML document

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ ServerTemplates are defined by a YAML format representing the ServerTemplate. Th
 | Description | String | Description field for the ServerTemplate. |
 | RightScripts | Hash of String -> Array of RightScripts| The hash key is the sequence type, one of "Boot", "Operational", or "Decommission". The hash value is a array of RightScripts. Each RightScript can be specified in one of two ways, as a locally managed RightScript and a "published" or "external" RightScript. A locally managed RightScript is specified as a pathname to a file on disk. Published RightScripts are links to RightScripts shared in the MultiCloud marketplace and consist of a hash specifying a Name/Revision/Publisher to look up.|
 | Inputs | Hash of String -> String | The hash key is the input name. The hash value is the default value. Note this inputs array is much simpler than the Input definition in RightScripts - only default values can be overridden in a ServerTemplate. |
-| MultiCloudImages | Array of MultiCloudImages | An array of MultiCloudImage definitions. A MultiCloudImage definition is a hash specifying a MCI. MCIs can be specified two different ways depending on Hash keys supplied: 1. 'Href' 2. 'Name' and 'Revision'. See example below. |
+| MultiCloudImages | Array of MultiCloudImages | An array of MultiCloudImage definitions. A MultiCloudImage definition is a hash specifying a MCI. MCIs can be specified three different ways depending on Hash keys supplied: 1. 'Href' 2. 'Name' and 'Revision'. 3. 'Name' and 'Revision' and 'Publisher'. If a publisher is supplied, will auto-import that MCI from the MultiCloud Marketplace.See example below. |
 | Alerts | Array of Alerts | An array of Alert definitions, defined below. |
 
 An Alert definition consists of three fields: a Name, Definition, and Clause (all strings). Clause is a text description of the Alert with this exact format: `If <Metric>.<ValueType> <ComparisonOperator> <Threshold> for <Duration> minutes Then <Action> <ActionValue>`.
@@ -153,6 +153,9 @@ RightScripts:
 MultiCloudImages:
 - Name: Ubuntu_14.04_x64
   Revision: 20
+- Name: Ubuntu_12.04_x64
+  Revision: 18
+  Publisher: RightScale
 - Href: /api/multi_cloud_images/403042003
 Alerts:
 - Name: CPU Scale Down

--- a/account.go
+++ b/account.go
@@ -40,10 +40,10 @@ type Account struct {
 }
 
 func (account *Account) Client15() (*cm15.API, error) {
-	if err := account.validate(); err != nil {
-		return nil, err
-	}
 	if account.client15 == nil {
+		if err := account.validate(); err != nil {
+			return nil, err
+		}
 		auth := rsapi.NewOAuthAuthenticator(account.RefreshToken, account.Id)
 		account.client15 = cm15.New(account.Host, auth)
 	}
@@ -51,10 +51,10 @@ func (account *Account) Client15() (*cm15.API, error) {
 }
 
 func (account *Account) Client16() (*cm16.API, error) {
-	if err := account.validate(); err != nil {
-		return nil, err
-	}
 	if account.client16 == nil {
+		if err := account.validate(); err != nil {
+			return nil, err
+		}
 		auth := rsapi.NewOAuthAuthenticator(account.RefreshToken, account.Id)
 		account.client16 = cm16.New(account.Host, auth)
 	}

--- a/alert.go
+++ b/alert.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rightscale/rsc/cm15"
+	"github.com/rightscale/rsc/rsapi"
+)
+
+type Alert struct {
+	Name        string `yaml:"Name"`
+	Description string `yaml:"Description,omitempty"`
+	Clause      string `yaml:"Clause"`
+}
+
+// Expected Format with array index offsets into tokens array below:
+// If <Metric>.<ValueType> <ComparisonOperator> <Threshold> for <Duration> minutes Then <Escalate|Grow|Shrink> <ActionValue>
+// 0  1                       2                    3           4   5          6       7    8                      9
+func parseAlertClause(alert string) (*cm15.AlertSpec, error) {
+	alertSpec := new(cm15.AlertSpec)
+	tokens := strings.SplitN(alert, " ", 10)
+	alertFmt := `If <Metric>.<ValueType> <ComparisonOperator> <Threshold> for <Duration> minutes Then <Action> <ActionValue>`
+	if len(tokens) != 10 {
+		return nil, fmt.Errorf("Alert clause misformatted: not long enough. Must be of format: '%s'", alertFmt)
+	}
+	if strings.ToLower(tokens[0]) != "if" {
+		return nil, fmt.Errorf("Alert clause misformatted: missing If. Must be of format: '%s'", alertFmt)
+	}
+	metricTokens := strings.Split(tokens[1], ".")
+	if len(metricTokens) != 2 {
+		return nil, fmt.Errorf("Alert <Metric>.<ValueType> misformatted, should be like 'cpu-0/cpu-idle.value'.")
+	}
+	// Check metricTokens[0] should contain a slash.
+	// Check metricTokens[1] can be numerous types: count, cumulative_requests, current_session, free
+	//   midterm, percent, processes, read, running, rx, tx, shortterm, state, status, threads,
+	//   used, users, value, write
+	alertSpec.File = metricTokens[0]
+	alertSpec.Variable = metricTokens[1]
+	comparisonValues := []string{">", ">=", "<", "<=", "==", "!="}
+	foundValue := false
+	for _, val := range comparisonValues {
+		if tokens[2] == val {
+			foundValue = true
+		}
+	}
+	if !foundValue {
+		return nil, fmt.Errorf("Alert <ComparisonOperator> must be one of the following comparison operators: %s", strings.Join(comparisonValues, ", "))
+	}
+	alertSpec.Condition = tokens[2]
+	// Threshold must be one of NaN, numeric OR booting, decommission, operational, pending, stranded, terminated
+	alertSpec.Threshold = tokens[3]
+	if strings.ToLower(tokens[4]) != "for" {
+		return nil, fmt.Errorf("Alert clause misformatted, missing 'for'. Must be of format: '%s'", alertFmt)
+	}
+	duration, err := strconv.Atoi(tokens[5])
+	if err != nil || duration < 1 {
+		return nil, fmt.Errorf("Alert <Duration> must be a positive integer > 0")
+	}
+	alertSpec.Duration = duration
+
+	if strings.Trim(strings.ToLower(tokens[6]), ",") != "minutes" {
+		return nil, fmt.Errorf("Alert clause misformatted: missing 'minutes'. Must be of format: '%s'", alertFmt)
+	}
+	if strings.ToLower(tokens[7]) != "then" {
+		return nil, fmt.Errorf("Alert clause misformatted: missing 'Then'. Must be of format: '%s'", alertFmt)
+	}
+	token8 := strings.ToLower(tokens[8])
+	if token8 != "escalate" && token8 != "grow" && token8 != "shrink" {
+		return nil, fmt.Errorf("Alert <Action> must be escalate, grow, or shrink")
+	}
+	if token8 == "escalate" {
+		alertSpec.EscalationName = tokens[9]
+	} else {
+		alertSpec.VoteType = token8
+		alertSpec.VoteTag = tokens[9]
+	}
+	return alertSpec, nil
+}
+
+// Complement to parseAlertClause
+// If <Metric>.<ValueType> <ComparisonOperator> <Threshold> for <Duration> minutes Then <Escalate|Grow|Shrink> <ActionValue>
+// 0  1                       2                    3           4   5          6       7    8                      9
+func printAlertClause(as cm15.AlertSpec) string {
+	var asAction, asActionValue string
+	if as.EscalationName != "" {
+		asAction = "escalate"
+		asActionValue = as.EscalationName
+	} else {
+		asAction = as.VoteType
+		asActionValue = as.VoteTag
+	}
+	alertStr := fmt.Sprintf("If %s.%s %s %s for %d minutes Then %s %s",
+		as.File, as.Variable, as.Condition, as.Threshold, as.Duration, asAction, asActionValue)
+	return alertStr
+}
+
+// Make sure an alert as described in yaml file on disk are correctly structured.
+func validateAlert(alert *Alert) error {
+	if alert.Name == "" {
+		return fmt.Errorf("Name field must be present")
+	}
+	_, err := parseAlertClause(alert.Clause)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Synchronizes alerts from the API to yaml file on disk
+func downloadAlerts(st *cm15.ServerTemplate) ([]*Alert, error) {
+	client, _ := Config.Account.Client15()
+
+	alertsLocator := client.AlertSpecLocator(getLink(st.Links, "alert_specs"))
+	alertSpecs, err := alertsLocator.Index(rsapi.APIParams{})
+	if err != nil {
+		return nil, fmt.Errorf("Could not find Alerts with href %s: %s", alertsLocator.Href, err.Error())
+	}
+	alerts := make([]*Alert, len(alertSpecs))
+	for i, alertSpec := range alertSpecs {
+		alerts[i] = &Alert{
+			Name:        alertSpec.Name,
+			Description: alertSpec.Description,
+			Clause:      printAlertClause(*alertSpec),
+		}
+	}
+	return alerts, nil
+}
+
+// Synchronizes alerts from yaml file on disk up to the API
+func uploadAlerts(stDef *ServerTemplate) error {
+	client, _ := Config.Account.Client15()
+
+	alertsLocator := client.AlertSpecLocator(stDef.href + "/alert_specs")
+	existingAlerts, err := alertsLocator.Index(rsapi.APIParams{})
+	if err != nil {
+		return fmt.Errorf("Could not find AlertSpecs with href %s: %s", alertsLocator.Href, err.Error())
+	}
+	seenAlert := make(map[string]bool)
+	alertLookup := make(map[string]*cm15.AlertSpec)
+	for _, alert := range existingAlerts {
+		alertLookup[alert.Name] = alert
+	}
+	// Add/Update alerts
+	for _, alert := range stDef.Alerts {
+		parsedAlert, _ := parseAlertClause(alert.Clause)
+		seenAlert[alert.Name] = true
+		existingAlert, ok := alertLookup[alert.Name]
+		if ok { // update
+			if alert.Clause != printAlertClause(*existingAlert) || alert.Description != existingAlert.Description {
+				alertsUpdateLocator := client.AlertSpecLocator(getLink(existingAlert.Links, "self"))
+
+				fmt.Printf("  Updating Alert %s\n", alert.Name)
+				params := cm15.AlertSpecParam2{
+					Condition:      parsedAlert.Condition,
+					Description:    alert.Description,
+					Duration:       strconv.Itoa(parsedAlert.Duration),
+					EscalationName: parsedAlert.EscalationName,
+					File:           parsedAlert.File,
+					Name:           alert.Name,
+					Threshold:      parsedAlert.Threshold,
+					Variable:       parsedAlert.Variable,
+					VoteTag:        parsedAlert.VoteTag,
+					VoteType:       parsedAlert.VoteType,
+				}
+				err := alertsUpdateLocator.Update(&params)
+				if err != nil {
+					return fmt.Errorf("Failed to update Alert %s: %s", alert.Name, err.Error())
+				}
+			}
+		} else { // new alert
+			fmt.Printf("  Adding Alert %s\n", alert.Name)
+			params := cm15.AlertSpecParam{
+				Condition:      parsedAlert.Condition,
+				Description:    alert.Description,
+				Duration:       strconv.Itoa(parsedAlert.Duration),
+				EscalationName: parsedAlert.EscalationName,
+				File:           parsedAlert.File,
+				Name:           alert.Name,
+				Threshold:      parsedAlert.Threshold,
+				Variable:       parsedAlert.Variable,
+				VoteTag:        parsedAlert.VoteTag,
+				VoteType:       parsedAlert.VoteType,
+			}
+			_, err := alertsLocator.Create(&params)
+			if err != nil {
+				return fmt.Errorf("Failed to create Alert %s: %s", alert.Name, err.Error())
+			}
+		}
+	}
+	for _, alert := range existingAlerts {
+		if !seenAlert[alert.Name] {
+			fmt.Printf("  Removing alert %s\n", alert.Name)
+			err := alert.Locator(client).Destroy()
+			if err != nil {
+				return fmt.Errorf("Could not destroy Alert %s: %s", alert.Name, err.Error())
+			}
+		}
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -347,6 +347,11 @@ func findPublication(kind string, name string, revision int, matchers map[string
 	client, err := Config.Account.Client15()
 
 	pubLocator := client.PublicationLocator("/api/publications")
+
+	if name == "" {
+		return nil, fmt.Errorf("No Name given when looking up %s publication", kind)
+	}
+
 	filters := []string{
 		"name==" + name,
 		"revision==" + fmt.Sprintf("%d", revision),
@@ -356,7 +361,7 @@ func findPublication(kind string, name string, revision int, matchers map[string
 	}
 	pubsUnfiltered, err := pubLocator.Index(rsapi.APIParams{"filter": filters})
 	if err != nil {
-		fatalError("Call to /api/publications failed: %s", err.Error())
+		return nil, fmt.Errorf("Call to /api/publications failed: %s", err.Error())
 	}
 	var pubs []*cm15.Publication
 	for _, pub := range pubsUnfiltered {

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ var (
 	stDownloadNameOrHref = stDownloadCmd.Arg("name|href|id", "Script Name or HREF or Id").Required().String()
 	stDownloadTo         = stDownloadCmd.Arg("path", "Download location").String()
 	stDownloadPublished  = stDownloadCmd.Flag("published", "Insert links to published RightScripts instead of downloading to disk.").Bool()
+	stDownloadImages     = stDownloadCmd.Flag("images", "Download image data to recreate an MCI from scratch (for cross-account imports)").Bool()
 
 	stValidateCmd   = stCmd.Command("validate", "Validate a ServerTemplate YAML document")
 	stValidatePaths = stValidateCmd.Arg("path", "Path to script file(s)").Required().ExistingFiles()
@@ -138,7 +139,7 @@ func main() {
 		if err != nil {
 			fatalError("%s", err.Error())
 		}
-		stDownload(href, *stDownloadTo, *stDownloadPublished)
+		stDownload(href, *stDownloadTo, *stDownloadPublished, *stDownloadImages)
 	case stValidateCmd.FullCommand():
 		files, err := walkPaths(*stValidatePaths)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -41,11 +41,11 @@ var (
 	stUploadPaths  = stUploadCmd.Arg("path", "File or directory containing script files to upload").Required().ExistingFilesOrDirs()
 	stUploadPrefix = stUploadCmd.Flag("prefix", "Add prefix to name all ServerTemplate and RightScripts uploaded (for testing purposes)").Short('x').String()
 
-	stDownloadCmd        = stCmd.Command("download", "Download a ServerTemplate and all associated RightScripts/Attachments to disk")
-	stDownloadNameOrHref = stDownloadCmd.Arg("name|href|id", "Script Name or HREF or Id").Required().String()
-	stDownloadTo         = stDownloadCmd.Arg("path", "Download location").String()
-	stDownloadPublished  = stDownloadCmd.Flag("published", "Insert links to published RightScripts instead of downloading to disk.").Bool()
-	stDownloadImages     = stDownloadCmd.Flag("images", "Download image data to recreate an MCI from scratch (for cross-account imports)").Bool()
+	stDownloadCmd         = stCmd.Command("download", "Download a ServerTemplate and all associated RightScripts/Attachments to disk")
+	stDownloadNameOrHref  = stDownloadCmd.Arg("name|href|id", "Script Name or HREF or Id").Required().String()
+	stDownloadTo          = stDownloadCmd.Arg("path", "Download location").String()
+	stDownloadPublished   = stDownloadCmd.Flag("published", "Insert links to published RightScripts instead of downloading to disk.").Bool()
+	stDownloadMciSettings = stDownloadCmd.Flag("mci-settings", "Download MCI settings data to recreate/manage an MCI.").Bool()
 
 	stValidateCmd   = stCmd.Command("validate", "Validate a ServerTemplate YAML document")
 	stValidatePaths = stValidateCmd.Arg("path", "Path to script file(s)").Required().ExistingFiles()
@@ -139,7 +139,7 @@ func main() {
 		if err != nil {
 			fatalError("%s", err.Error())
 		}
-		stDownload(href, *stDownloadTo, *stDownloadPublished, *stDownloadImages)
+		stDownload(href, *stDownloadTo, *stDownloadPublished, *stDownloadMciSettings)
 	case stValidateCmd.FullCommand():
 		files, err := walkPaths(*stValidatePaths)
 		if err != nil {

--- a/mci.go
+++ b/mci.go
@@ -12,6 +12,7 @@ type Setting struct {
 	Cloud            string `yaml:"Cloud"`
 	InstanceType     string `yaml:"Instance Type"`
 	Image            string `yaml:"Image"`
+	UserData         string `yaml:"User Data"`
 	cloudHref        string
 	instanceTypeHref string
 	imageHref        string
@@ -333,7 +334,8 @@ func uploadMultiCloudImages(stDef *ServerTemplate, prefix string) error {
 							CloudHref:        s.cloudHref,
 							ImageHref:        s.imageHref,
 							InstanceTypeHref: s.instanceTypeHref,
-							// unsupported: UserData, KernelImageHref, RamdiskImageHref
+							UserData:         s.UserData,
+							// unsupported: KernelImageHref, RamdiskImageHref
 						}
 
 						err := s2.Locator(client).Update(&updateParams)
@@ -348,7 +350,8 @@ func uploadMultiCloudImages(stDef *ServerTemplate, prefix string) error {
 						CloudHref:        s.cloudHref,
 						ImageHref:        s.imageHref,
 						InstanceTypeHref: s.instanceTypeHref,
-						// unsupported: UserData, KernelImageHref, RamdiskImageHref
+						UserData:         s.UserData,
+						// unsupported: KernelImageHref, RamdiskImageHref
 					}
 					_, err := settingsLoc.Create(&createParams)
 					if err != nil {

--- a/mci.go
+++ b/mci.go
@@ -297,12 +297,13 @@ func uploadMultiCloudImages(stDef *ServerTemplate, prefix string) error {
 					return fmt.Errorf("API call to create MultiCloudImage '%s' failed: %s", mciName, err.Error())
 				}
 				href = string(loc.Href)
+				fmt.Printf("  Created MultiCloudImage with name '%s': %s\n", mciName, href)
 			} else {
 				mci, err := client.MultiCloudImageLocator(href).Show()
 				if err != nil {
 					return fmt.Errorf("API call failed: %s", err.Error())
 				}
-
+				fmt.Printf("  Updating MultiCloudImage '%s'\n", mciName)
 				if mci.Description != mciDef.Description {
 					err := mci.Locator(client).Update(&cm15.MultiCloudImageParam{Description: mciDef.Description})
 					if err != nil {

--- a/mci.go
+++ b/mci.go
@@ -1,0 +1,436 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rightscale/rsc/cm15"
+	"github.com/rightscale/rsc/rsapi"
+)
+
+type Setting struct {
+	Cloud            string `yaml:"Cloud"`
+	InstanceType     string `yaml:"Instance Type"`
+	Image            string `yaml:"Image"`
+	cloudHref        string
+	instanceTypeHref string
+	imageHref        string
+}
+
+type MultiCloudImage struct {
+	Href        string `yaml:"Href,omitempty"`
+	Name        string `yaml:"Name,omitempty"`
+	Description string `yaml:"Description,omitempty"`
+	Revision    int    `yaml:"Revision,omitempty"`
+	Publisher   string `yaml:"Publisher,omitempty"`
+	// Settings are like MultiCloudImageSettings, defining cloud/resource_uid sets
+	Settings []*Setting `yaml:"Settings,omitempty"`
+}
+
+// Cache lookups for below
+var cloudsLookup []*cm15.Cloud
+var instanceTypesLookup map[string][]*cm15.InstanceType
+
+// Let people specify MCIs multiple ways:
+//   1. Href (Sort of there for completeness and to break ties for 2. may remove at some point)
+//   2. Name/Revision pair (similar to above, but at least somewhat portable)
+//   3. Name/Revision/Publisher triplet (preferred -- more portable)
+//   4. Set of Images + Tags to support autocreation/management of MCIs
+func validateMultiCloudImage(mciDef *MultiCloudImage) (errors []error) {
+	client, _ := Config.Account.Client15()
+
+	if instanceTypesLookup == nil {
+		cl, err := client.CloudLocator("/api/clouds").Index(rsapi.APIParams{})
+		if err != nil {
+			fatalError("Could not execute API call to get clouds: %s", err.Error())
+		}
+		cloudsLookup = cl
+		instanceTypesLookup = make(map[string][]*cm15.InstanceType)
+	}
+
+	if mciDef.Href != "" {
+		loc := client.MultiCloudImageLocator(mciDef.Href)
+		mci, err := loc.Show()
+		if err != nil {
+			errors = append(errors, fmt.Errorf("Could not find MCI HREF %s in account", mciDef.Href))
+		}
+		mciDef.Name = mci.Name
+		mciDef.Revision = mci.Revision
+	} else if len(mciDef.Settings) > 0 {
+		for i, s := range mciDef.Settings {
+			if s.Cloud == "" || s.InstanceType == "" || s.Image == "" {
+				errors = append(errors, fmt.Errorf("Invalid setting, Cloud, Instance Type, and Image fields must be set\n"))
+				return
+			}
+			for _, c := range cloudsLookup {
+				if getLink(c.Links, "self") == s.Cloud || c.DisplayName == s.Cloud || c.Name == s.Cloud {
+					mciDef.Settings[i].cloudHref = getLink(c.Links, "self")
+				}
+			}
+			if mciDef.Settings[i].cloudHref == "" {
+				errors = append(errors, fmt.Errorf("Cannot find cloud %s for MCI '%s' Setting #%d",
+					s.Cloud, mciDef.Name, i+1))
+				return
+			}
+			if _, ok := instanceTypesLookup[mciDef.Settings[i].cloudHref]; !ok {
+				its, err := client.InstanceTypeLocator(mciDef.Settings[i].cloudHref + "/instance_types").Index(rsapi.APIParams{})
+				if err != nil {
+					errors = append(errors, fmt.Errorf("WARNING: Could not complete API call: %s\n", err.Error()))
+				}
+				instanceTypesLookup[mciDef.Settings[i].cloudHref] = its
+			}
+			for _, it := range instanceTypesLookup[mciDef.Settings[i].cloudHref] {
+				if it.Name == s.InstanceType || it.ResourceUid == s.InstanceType {
+					mciDef.Settings[i].instanceTypeHref = getLink(it.Links, "self")
+				}
+			}
+			if mciDef.Settings[i].instanceTypeHref == "" {
+				errors = append(errors, fmt.Errorf("Cannot find instance type %s for MCI '%s' Setting #%d",
+					s.InstanceType, mciDef.Name, i+1))
+			}
+
+			apiParams := rsapi.APIParams{"filter": []string{"resource_uid==" + s.Image}}
+			images, err := client.ImageLocator(mciDef.Settings[i].cloudHref + "/images").Index(apiParams)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("WARNING: Could not complete API call: %s\n", err.Error()))
+			}
+			if len(images) < 1 {
+				errors = append(errors, fmt.Errorf("Cannot find image with resource_uid %s for MCI '%s' Setting #%d",
+					s.Image, mciDef.Name, i+1))
+			} else {
+				mciDef.Settings[i].imageHref = getLink(images[0].Links, "self")
+			}
+
+		}
+	} else if mciDef.Publisher != "" {
+		pub, err := findPublication("MultiCloudImage", mciDef.Name, mciDef.Revision,
+			map[string]string{`Publisher`: mciDef.Publisher})
+		if err != nil {
+			errors = append(errors, fmt.Errorf("Error finding publication for MultiCloudImage: %s\n", err.Error()))
+		}
+		if pub == nil {
+			errors = append(errors, fmt.Errorf("Could not find a publication in the MultiCloud Marketplace for MultiCloudImage '%s' Revision %d Publisher '%s'",
+				mciDef.Name, mciDef.Revision, mciDef.Publisher))
+		}
+	} else if mciDef.Name != "" {
+		href, err := paramToHref("multi_cloud_images", mciDef.Name, mciDef.Revision)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("Could not find MCI named '%s' with revision %d in account",
+				mciDef.Name, mciDef.Revision))
+		}
+		mciDef.Href = href
+	} else {
+		errors = append(errors, fmt.Errorf("MultiCloudImage item must be a hash with Settings, Name/Revision, or Name/Revision/Publisher keys set to a valid values."))
+	}
+	return
+}
+
+func downloadMultiCloudImages(st *cm15.ServerTemplate, useImages bool) ([]*MultiCloudImage, error) {
+	client, _ := Config.Account.Client15()
+
+	mciLocator := client.MultiCloudImageLocator(getLink(st.Links, "multi_cloud_images"))
+	apiMcis, err := mciLocator.Index(rsapi.APIParams{})
+	if err != nil {
+		return nil, fmt.Errorf("Could not find MCIs with href %s: %s", mciLocator.Href, err.Error())
+	}
+	mciImages := make([]*MultiCloudImage, 0)
+	for _, mci := range apiMcis {
+		if useImages {
+			settingsLoc := client.MultiCloudImageSettingLocator(getLink(mci.Links, "settings"))
+			settings, err := settingsLoc.Index(rsapi.APIParams{})
+			if err != nil {
+				return nil, fmt.Errorf("Could not get MultiCloudImage settings %s: %s\n", getLink(mci.Links, "settings"), err.Error())
+			}
+			mciSettings := make([]*Setting, 0)
+			for _, s := range settings {
+				cloud, err := client.CloudLocator(getLink(s.Links, "cloud")).Show(rsapi.APIParams{})
+				if err != nil {
+					if strings.Contains(err.Error(), "ResourceNotFound") {
+						fmt.Printf("WARNING: For MCI '%s', skipping setting for cloud %s: cloud isn't registered in this account.\n",
+							mci.Name, getLink(s.Links, "cloud"))
+						continue
+					} else {
+						return nil, fmt.Errorf("Could not complete API call: %s\n", err.Error())
+					}
+				}
+				if getLink(s.Links, "instance_type") == "" {
+					fmt.Printf("WARNING: For MCI '%s', skipping setting for cloud %s: fingerprinted MCIs not supported by this tool.\n",
+						mci.Name, getLink(s.Links, "cloud"))
+					continue
+				}
+				instanceType, err := client.InstanceTypeLocator(getLink(s.Links, "instance_type")).Show(rsapi.APIParams{})
+				if err != nil {
+					return nil, fmt.Errorf("Could not complete API call: %s\n", err.Error())
+				}
+				image, err := client.ImageLocator(getLink(s.Links, "image")).Show(rsapi.APIParams{})
+				if err != nil {
+					fmt.Printf("WARNING: Could not complete API call: %s\n", err.Error())
+					continue
+				}
+
+				mciSetting := Setting{Cloud: cloud.Name, InstanceType: instanceType.ResourceUid, Image: image.ResourceUid}
+				mciSettings = append(mciSettings, &mciSetting)
+			}
+			if len(mciSettings) > 0 {
+				mciImages = append(mciImages, &MultiCloudImage{Name: mci.Name, Description: mci.Description, Settings: mciSettings})
+			} else {
+				fmt.Printf("WARNING: skipping MCI '%s', contains no usable settings\n", mci.Name)
+			}
+		} else {
+			// We repull the MCI here to get the description field, which we need to break ties between
+			// similarly named publications!
+			mciLoc := client.MultiCloudImageLocator(getLink(mci.Links, "self"))
+			mci, err := mciLoc.Show()
+			if err != nil {
+				return nil, fmt.Errorf("Could not get MultiCloudImage %s: %s\n", getLink(mci.Links, "self"), err.Error())
+			}
+			pub, err := findPublication("MultiCloudImage", mci.Name, mci.Revision, map[string]string{`Description`: mci.Description})
+			if err != nil {
+				return nil, fmt.Errorf("Error finding publication: %s\n", err.Error())
+			}
+			mciImage := MultiCloudImage{Name: mci.Name, Revision: mci.Revision, Description: mci.Description}
+			if pub != nil {
+				mciImage.Publisher = pub.Publisher
+			}
+			mciImages = append(mciImages, &mciImage)
+		}
+
+	}
+	return mciImages, nil
+}
+
+func uploadMultiCloudImages(stDef *ServerTemplate, prefix string) error {
+	client, _ := Config.Account.Client15()
+
+	stMciLocator := client.ServerTemplateMultiCloudImageLocator("/api/server_template_multi_cloud_images")
+
+	existingMcis, err := stMciLocator.Index(rsapi.APIParams{"filter": []string{"server_template_href==" + stDef.href}})
+	if err != nil {
+		fatalError("Could not find MCIs with href %s: %s", stMciLocator.Href, err.Error())
+	}
+
+	// Algorithm for linking Publications:
+	//   1. For MultiCloudImages with a publication, find the publications first. Get the name/description/publisher
+	//   2. If we don't find it, throw an error
+	//   3. Get the imported MultiCloudImages. If it doesn't exist, import it then get the href
+	//   4. Insert HREF into r struct for later use.
+	for _, mciDef := range stDef.MultiCloudImages {
+		if mciDef.Publisher != "" {
+			pub, err := findPublication("MultiCloudImage", mciDef.Name, mciDef.Revision,
+				map[string]string{`Publisher`: mciDef.Publisher})
+			if err != nil {
+				fatalError("Could not lookup publication %s", err.Error())
+			}
+			if pub == nil {
+				fatalError("Could not find a publication in the MultiCloud Marketplace for MultiCloudImage '%s' Revision %d Publisher '%s'",
+					mciDef.Name, mciDef.Revision, mciDef.Publisher)
+			}
+
+			mciLocator := client.MultiCloudImageLocator("/api/multi_cloud_images")
+			filters := []string{
+				"name==" + mciDef.Name,
+			}
+
+			mciUnfiltered, err := mciLocator.Index(rsapi.APIParams{"filter": filters})
+			if err != nil {
+				fatalError("Error looking up MCI: %s", err.Error())
+			}
+			for _, mci := range mciUnfiltered {
+				// Recheck the name here, filter does a partial match and we need an exact one.
+				// Matching the descriptions helps to disambiguate if we have multiple publications
+				// with that same name/revision pair.
+				if mci.Name == mciDef.Name && mci.Revision == mciDef.Revision && mci.Description == pub.Description {
+					mciDef.Href = getLink(mci.Links, "self")
+				}
+			}
+
+			if mciDef.Href == "" {
+				loc := pub.Locator(client)
+
+				err = loc.Import()
+
+				if err != nil {
+					return fmt.Errorf("Failed to import publication %s for MultiCloudImage '%s' Revision %d Publisher %s\n",
+						getLink(pub.Links, "self"), mciDef.Name, mciDef.Revision, mciDef.Publisher)
+				}
+
+				mciUnfiltered, err := mciLocator.Index(rsapi.APIParams{"filter": filters})
+				if err != nil {
+					fatalError("Error looking up MCI: %s", err.Error())
+				}
+				for _, mci := range mciUnfiltered {
+					if mci.Name == mciDef.Name && mci.Revision == mciDef.Revision && mci.Description == pub.Description {
+						mciDef.Href = getLink(mci.Links, "self")
+					}
+				}
+				if mciDef.Href == "" {
+					return fmt.Errorf("Could not refind MultiCloudImage '%s' Revision %d after import!", mciDef.Name, mciDef.Revision)
+				}
+			}
+		}
+	}
+
+	// For MCIs managed by us, we create them as needed. All Hrefs to cloud/instance type objects should be resolved
+	// during the validation step, so we should be good to go
+	for _, mciDef := range stDef.MultiCloudImages {
+		if len(mciDef.Settings) > 0 {
+			mciName := mciDef.Name
+			if prefix != "" {
+				mciName = fmt.Sprintf("%s_%s", prefix, mciName)
+			}
+
+			href, err := paramToHref("multi_cloud_images", mciName, 0)
+			if err != nil && !strings.Contains(err.Error(), "Found no multi_cloud_images matching") {
+				return fmt.Errorf("API call to find MultiCloudImage '%s' failed: %s", mciName, err.Error())
+			}
+			if href == "" {
+				createParams := cm15.MultiCloudImageParam{Description: mciDef.Description, Name: mciName}
+				loc, err := client.MultiCloudImageLocator("/api/multi_cloud_images").Create(&createParams)
+				if err != nil {
+					return fmt.Errorf("API call to create MultiCloudImage '%s' failed: %s", mciName, err.Error())
+				}
+				href = string(loc.Href)
+			}
+			mciDef.Href = href
+			// get existing settings
+			settingsLoc := client.MultiCloudImageSettingLocator(mciDef.Href + "/settings")
+			settings, err := settingsLoc.Index(rsapi.APIParams{})
+			if err != nil {
+				fatalError("Could not get MultiCloudImage settings %s: %s\n", mciDef.Href, err.Error())
+			}
+			seenSettings := make(map[string]bool)
+
+			for _, s := range mciDef.Settings {
+				// for each desired setting, if existing setting with same cloud exists, update it. else add it.
+				updated := false
+				seenSettings[s.cloudHref] = true
+				for _, s2 := range settings {
+					if s.cloudHref == getLink(s2.Links, "cloud") {
+						updateParams := cm15.MultiCloudImageSettingParam{
+							CloudHref:        s.cloudHref,
+							ImageHref:        s.imageHref,
+							InstanceTypeHref: s.instanceTypeHref,
+							// unsupported: UserData, KernelImageHref, RamdiskImageHref
+						}
+
+						err := s2.Locator(client).Update(&updateParams)
+						if err != nil {
+							fatalError("Could not update MultiCloudImage setting %s: %s\n", getLink(s2.Links, "self"), err.Error())
+						}
+						updated = true
+					}
+				}
+				if !updated {
+					createParams := cm15.MultiCloudImageSettingParam{
+						CloudHref:        s.cloudHref,
+						ImageHref:        s.imageHref,
+						InstanceTypeHref: s.instanceTypeHref,
+						// unsupported: UserData, KernelImageHref, RamdiskImageHref
+					}
+					_, err := settingsLoc.Create(&createParams)
+					if err != nil {
+						fatalError("Could not create MultiCloudImage setting %s: %s\n", mciDef.Href, err.Error())
+					}
+				}
+			}
+			// for existing settings not in desired settings, remove them
+			for _, s := range settings {
+				if !seenSettings[getLink(s.Links, "cloud")] {
+					err := s.Locator(client).Destroy()
+					if err != nil {
+						fatalError("  Could not Remove MCI Setting for MCI '%s' with Cloud '%s': %s",
+							mciName, getLink(s.Links, "cloud"), err.Error())
+					}
+				}
+			}
+		}
+	}
+
+	// Delete MCIs that exist on the existing ST but not in this definition. We perform all the deletions first so
+	// we don't have to worry about reading the same MCI with a different revision and throwing an error later
+	// firstValidMci is an MCI we know for sure we're not going to default. We can't delete an MCI marked default so
+	// make the firstValidMci the default in that case then proceed with the delete.
+	var firstValidMci *cm15.ServerTemplateMultiCloudImageLocator
+	for _, mci := range existingMcis {
+		mciHref := getLink(mci.Links, "multi_cloud_image")
+		for _, mciDef := range stDef.MultiCloudImages {
+			if mciDef.Href == mciHref {
+				firstValidMci = mci.Locator(client)
+				break
+			}
+		}
+		if firstValidMci != nil {
+			break
+		}
+	}
+	// Dummy MCI. If we can't find ANY valid Mcis, that means we're going to delete all the existing attached MCIs
+	// before adding any new ones. This presents a problem in that the API will return an error if you try and delete
+	// the final MCI. We work around this by adding a dummy MCI we later delete
+	if firstValidMci == nil {
+		mciLocator := client.MultiCloudImageLocator("/api/multi_cloud_images")
+
+		dummyMcis, err := mciLocator.Index(rsapi.APIParams{})
+		if err != nil {
+			fatalError("Failed to find dummy MCIs: %s", mciLocator.Href, err.Error())
+		}
+		params := cm15.ServerTemplateMultiCloudImageParam{
+			MultiCloudImageHref: getLink(dummyMcis[0].Links, "self"),
+			ServerTemplateHref:  stDef.href,
+		}
+		loc, err := stMciLocator.Create(&params)
+		if err != nil {
+			fatalError("  Failed to associate Dummy MCI '%s' with ServerTemplate '%s': %s", getLink(dummyMcis[0].Links, "self"), stDef.href, err.Error())
+		}
+		firstValidMci = loc
+		defer loc.Destroy()
+	}
+	for _, mci := range existingMcis {
+		mciHref := getLink(mci.Links, "multi_cloud_image")
+		foundMci := false // found on ST definition
+		for _, mciDef := range stDef.MultiCloudImages {
+			if mciDef.Href == mciHref {
+				foundMci = true
+			}
+		}
+		if !foundMci {
+			fmt.Printf("  Removing MCI %s\n", mciHref)
+			if mci.IsDefault {
+				firstValidMci.MakeDefault()
+			}
+			err := mci.Locator(client).Destroy()
+			if err != nil {
+				fatalError("  Could not Remove MCI %s", mciHref)
+			}
+		}
+	}
+
+	// Add all MCIs.
+	for i, mciDef := range stDef.MultiCloudImages {
+		foundMci := false // found on ST
+		for _, mci := range existingMcis {
+			mciHref := getLink(mci.Links, "multi_cloud_image")
+			if mciDef.Href == mciHref {
+				foundMci = true
+			}
+		}
+		if !foundMci {
+			params := cm15.ServerTemplateMultiCloudImageParam{
+				MultiCloudImageHref: mciDef.Href,
+				ServerTemplateHref:  stDef.href,
+			}
+			mciName := mciDef.Name
+			if prefix != "" {
+				mciName = fmt.Sprintf("%s_%s", prefix, mciName)
+			}
+			fmt.Printf("  Adding MCI '%s' revision '%d' (%s)\n", mciName, mciDef.Revision, mciDef.Href)
+			loc, err := stMciLocator.Create(&params)
+			if err != nil {
+				fatalError("  Failed to associate MCI '%s' with ServerTemplate '%s': %s", mciDef.Href, stDef.href, err.Error())
+			}
+			if i == 0 {
+				_ = loc.MakeDefault()
+			}
+		}
+	}
+	return nil
+}

--- a/mci.go
+++ b/mci.go
@@ -82,7 +82,7 @@ func validateMultiCloudImage(mciDef *MultiCloudImage) (errors []error) {
 				instanceTypesLookup[mciDef.Settings[i].cloudHref] = its
 			}
 			for _, it := range instanceTypesLookup[mciDef.Settings[i].cloudHref] {
-				if it.Name == s.InstanceType || it.ResourceUid == s.InstanceType {
+				if getLink(it.Links, "self") == s.InstanceType || it.Name == s.InstanceType || it.ResourceUid == s.InstanceType {
 					mciDef.Settings[i].instanceTypeHref = getLink(it.Links, "self")
 				}
 			}

--- a/mci.go
+++ b/mci.go
@@ -12,7 +12,7 @@ type Setting struct {
 	Cloud            string `yaml:"Cloud"`
 	InstanceType     string `yaml:"Instance Type"`
 	Image            string `yaml:"Image"`
-	UserData         string `yaml:"User Data"`
+	UserData         string `yaml:"User Data,omitempty"`
 	cloudHref        string
 	instanceTypeHref string
 	imageHref        string
@@ -127,7 +127,7 @@ func validateMultiCloudImage(mciDef *MultiCloudImage) (errors []error) {
 	return
 }
 
-func downloadMultiCloudImages(st *cm15.ServerTemplate, useImages bool) ([]*MultiCloudImage, error) {
+func downloadMultiCloudImages(st *cm15.ServerTemplate, downloadMciSettings bool) ([]*MultiCloudImage, error) {
 	client, _ := Config.Account.Client15()
 
 	mciLocator := client.MultiCloudImageLocator(getLink(st.Links, "multi_cloud_images"))
@@ -137,7 +137,7 @@ func downloadMultiCloudImages(st *cm15.ServerTemplate, useImages bool) ([]*Multi
 	}
 	mciImages := make([]*MultiCloudImage, 0)
 	for _, mci := range apiMcis {
-		if useImages {
+		if downloadMciSettings {
 			tags, err := getTagsByHref(getLink(mci.Links, "self"))
 			if err != nil {
 				return nil, fmt.Errorf("Could not get tags for MultiCloudImage '%s': %s\n", getLink(mci.Links, "self"), err.Error())

--- a/rightscript.go
+++ b/rightscript.go
@@ -447,7 +447,7 @@ func (r *RightScript) PushRemote() error {
 		return err
 	}
 	if pub == nil {
-		return fmt.Errorf("Could not find a publication in library for RightScript '%s' Revision %d Publisher '%s'\n", r.Name, r.Revision, r.Publisher)
+		return fmt.Errorf("Could not find a publication in the MultiCloud Marketplace for RightScript '%s' Revision %d Publisher '%s'", r.Name, r.Revision, r.Publisher)
 	}
 
 	rsLocator := client.RightScriptLocator("/api/right_scripts")
@@ -483,10 +483,7 @@ func (r *RightScript) PushRemote() error {
 			return err
 		}
 		for _, rs := range rsUnfiltered {
-			// Recheck the name here, filter does a partial match and we need an exact one.
-			// Matching the descriptions helps to disambiguate if we have multiple publications
-			// with that same name/revision pair.
-			if rs.Name == r.Name && rs.Description == pub.Description {
+			if rs.Name == r.Name && rs.Revision == r.Revision && rs.Description == pub.Description {
 				r.Href = getLink(rs.Links, "self")
 			}
 		}

--- a/servertemplate.go
+++ b/servertemplate.go
@@ -93,6 +93,13 @@ func doServerTemplateUpload(stDef *ServerTemplate, prefix string) error {
 			fatalError("Failed to refetch ServerTemplate '%s': %s", stLoc.Href, err.Error())
 		}
 		stVerb = "Creating"
+	} else {
+		if st.Description != stDef.Description {
+			err := st.Locator(client).Update(&cm15.ServerTemplateParam{Description: stDef.Description})
+			if err != nil {
+				fatalError("Failed to update ServerTemplate '%s' description: %s", stName, err.Error())
+			}
+		}
 	}
 	stDef.href = getLink(st.Links, "self")
 	fmt.Printf("%s ServerTemplate with HREF %s\n", stVerb, stDef.href)

--- a/servertemplate.go
+++ b/servertemplate.go
@@ -340,7 +340,7 @@ func stShow(href string) {
 	}
 }
 
-func stDownload(href, downloadTo string, usePublished bool, useImages bool) {
+func stDownload(href, downloadTo string, usePublished bool, downloadMciSettings bool) {
 	client, err := Config.Account.Client15()
 	if err != nil {
 		fatalError("Could not find ServerTemplate with href %s: %s", href, err.Error())
@@ -363,7 +363,7 @@ func stDownload(href, downloadTo string, usePublished bool, useImages bool) {
 	//-------------------------------------
 	// MultiCloudImages
 	//-------------------------------------
-	mcis, err := downloadMultiCloudImages(st, useImages)
+	mcis, err := downloadMultiCloudImages(st, downloadMciSettings)
 	if err != nil {
 		fatalError("Could not get MCIs from API: %s", err.Error())
 	}

--- a/servertemplate_test.go
+++ b/servertemplate_test.go
@@ -38,6 +38,11 @@ MultiCloudImages:
   - Name: FooCorpImage
     Revision: 100
     Publisher: FooCorp
+  - Name: ImageBasedMci
+    Settings:
+    - Cloud: AWS US-West
+      Instance Type: t1.micro
+      Image: ami-e305efa7
 `)
 			It("should parse correctly", func() {
 				dummy1List := []*RightScript{
@@ -60,6 +65,9 @@ MultiCloudImages:
 					&MultiCloudImage{Href: "/api/multi_cloud_images/403042003"},
 					&MultiCloudImage{Name: "FooImage", Revision: 100},
 					&MultiCloudImage{Name: "FooCorpImage", Revision: 100, Publisher: "FooCorp"},
+					&MultiCloudImage{Name: "ImageBasedMci", Settings: []*Setting{
+						&Setting{Cloud: "AWS US-West", InstanceType: "t1.micro", Image: "ami-e305efa7"},
+					}},
 				}))
 			})
 		})

--- a/servertemplate_test.go
+++ b/servertemplate_test.go
@@ -29,6 +29,12 @@ RightScripts:
     - Dummy2.sh
   Decommission:
     - Dummy3.sh
+Alerts:
+- Name: CPU Scale Down
+  Description: Votes to shrink ServerArray
+  Clause: If cpu-0/cpu-idle.value > '50' for 3 minutes Then shrink my_app_name
+- Name: Low memory warning
+  Clause: If memory/memory-free.value < 100000000 for 5 minutes Then escalate warning
 Inputs:
   SERVER_HOSTNAME: text:test.local
 MultiCloudImages:
@@ -57,6 +63,13 @@ MultiCloudImages:
 				Expect(st).NotTo(BeNil())
 				Expect(st.Name).To(Equal("Test ST"))
 				Expect(st.Description).To(Equal("Test ST Description"))
+				Expect(st.Alerts).To(Equal([]*Alert{
+					&Alert{Name: "CPU Scale Down",
+						Description: "Votes to shrink ServerArray",
+						Clause:      "If cpu-0/cpu-idle.value > '50' for 3 minutes Then shrink my_app_name"},
+					&Alert{Name: "Low memory warning",
+						Clause: "If memory/memory-free.value < 100000000 for 5 minutes Then escalate warning"},
+				}))
 				Expect(st.Inputs).To(Equal(map[string]*InputValue{"SERVER_HOSTNAME": &InputValue{Type: "text", Value: "test.local"}}))
 				Expect(st.RightScripts["Boot"]).To(Equal(dummy1List))
 				Expect(st.RightScripts["Operational"]).To(Equal(dummy2List))

--- a/servertemplate_test.go
+++ b/servertemplate_test.go
@@ -35,6 +35,9 @@ MultiCloudImages:
   - Href: /api/multi_cloud_images/403042003
   - Name: FooImage
     Revision: 100
+  - Name: FooCorpImage
+    Revision: 100
+    Publisher: FooCorp
 `)
 			It("should parse correctly", func() {
 				dummy1List := []*RightScript{
@@ -56,6 +59,7 @@ MultiCloudImages:
 				Expect(st.MultiCloudImages).To(Equal([]*MultiCloudImage{
 					&MultiCloudImage{Href: "/api/multi_cloud_images/403042003"},
 					&MultiCloudImage{Name: "FooImage", Revision: 100},
+					&MultiCloudImage{Name: "FooCorpImage", Revision: 100, Publisher: "FooCorp"},
 				}))
 			})
 		})

--- a/servertemplate_test.go
+++ b/servertemplate_test.go
@@ -49,6 +49,7 @@ MultiCloudImages:
     - Cloud: AWS US-West
       Instance Type: t1.micro
       Image: ami-e305efa7
+      User Data: Foo
 `)
 			It("should parse correctly", func() {
 				dummy1List := []*RightScript{
@@ -79,7 +80,7 @@ MultiCloudImages:
 					&MultiCloudImage{Name: "FooImage", Revision: 100},
 					&MultiCloudImage{Name: "FooCorpImage", Revision: 100, Publisher: "FooCorp"},
 					&MultiCloudImage{Name: "ImageBasedMci", Settings: []*Setting{
-						&Setting{Cloud: "AWS US-West", InstanceType: "t1.micro", Image: "ami-e305efa7"},
+						&Setting{Cloud: "AWS US-West", InstanceType: "t1.micro", Image: "ami-e305efa7", UserData: "Foo"},
 					}},
 				}))
 			})


### PR DESCRIPTION
Add option to ST download (--mci-settings) which defines MCIs in terms of their Cloud/Image/Instance Type combinations. Still two shortcomings with this approach:
1. Lack of fingerprinted MCIs - need to add right_api support for this.
2. You can set User Data for an MCI setting, but you can't read it back out from the API. This means you still have to hand tweak the definition of MCI settings which need this.