### PR TITLE
update scriptPath to new filename format in yml file

### DIFF
--- a/servertemplate.go
+++ b/servertemplate.go
@@ -431,8 +431,8 @@ func stDownload(href, downloadTo string, usePublished bool, downloadMciSettings 
 				if err != nil {
 					fatalError("Error creating directory: %s", err.Error())
 				}
-				rightScriptDownload(rsHref, filepath.Join(filepath.Dir(downloadTo), scriptPath))
-				newScript.Path = scriptPath + "/" + cleanFileName(rb.RightScript.Name)
+				downloadedTo := rightScriptDownload(rsHref, filepath.Join(filepath.Dir(downloadTo), scriptPath))
+				newScript.Path = strings.TrimPrefix(downloadedTo, filepath.Dir(downloadTo)+string(filepath.Separator))
 			}
 		}
 	}


### PR DESCRIPTION
when the script-path option was specified, the rightscript file names in the server template yml file were using the old format. Updated to new format with file name extensions.