### PR TITLE
Duplicate attachment names

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,13 @@ unreleased changes
 -------------------
 * Add `--script-path` argument to specify where to download RightScripts relative
   to the ServerTemplate download location ([#28])
-* Fix a panic in ServerTemplate validate when the RightScript name is not known yet
+* Fix a panic in ServerTemplate validate when the RightScript name is not known
+  yet
+* If multiple RightScripts in a ServerTemplate contain an attachment with the
+  same name, now download those attachments to different directories ([#19])
 
 [#28]: https://github.com/rightscale/right_st/pull/28
+[#19]: https://github.com/rightscale/right_st/pull/19
 
 v1.3.0 / 2016-07-15
 -------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@ unreleased changes
 * Fix a panic in ServerTemplate validate when the RightScript name is not known
   yet
 * If multiple RightScripts in a ServerTemplate contain an attachment with the
-  same name, now download those attachments to different directories ([#19])
+  same name, download those attachments to different subdirectories ([#19])
 
 [#28]: https://github.com/rightscale/right_st/pull/28
 [#19]: https://github.com/rightscale/right_st/pull/19

--- a/rightscript.go
+++ b/rightscript.go
@@ -236,7 +236,6 @@ func rightScriptDownload(href, downloadTo string) string {
 			fatalError("Failed to download all attachments: %s", err.Error())
 		}
 		for _, d := range downloadItems {
-			fmt.Printf("DLITEM\n  %#v\n", d)
 			for i, attachment := range attachments {
 				if filepath.Base(attachment.Filename) == filepath.Base(d.downloadedTo) {
 					attachments[i].Filename = strings.TrimLeft(d.downloadedTo, pathPrepend)


### PR DESCRIPTION
Download attachmetns with duplicated names into separate subdir based upon the cleaned up version of the rightscript name. Example:
RightScript script1 has attachments foo, bar
RightScript script2 has attachments foo, baz

Attachments will be downloaded as:
attachments/foo, attachments/bar, attachments/script2/foo, attachments/baz
