### PR TITLE
Guess extension .ps1 (fixes #40)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache:
   directories:
     - vendor
 before_install:
-  - "[[ $TRAVIS_OS_NAME != osx ]] || brew list bash || brew install bash"
-  - "[[ $TRAVIS_OS_NAME != osx ]] || brew list coreutils || brew install coreutils"
+  - "[[ $TRAVIS_OS_NAME != osx ]] || brew list bash || (brew update && brew install bash)"
+  - "[[ $TRAVIS_OS_NAME != osx ]] || brew list coreutils || (brew update && brew install coreutils)"
 install:
   - make depend
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 env:
   - GO15VENDOREXPERIMENT=1
 go:
-  - 1.8.x
+  - 1.9.x
 os:
   - linux
   - osx

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+unreleased changes
+-------------------
+* Add file extension guessing for PowerShell RightScript download using either a
+  shebang or some heuristics.
+
 v1.6.3 / 2017-08-03
 -------------------
 * Work around a bug with account selection due to [viper]'s case-insensitivity.

--- a/rightscript.go
+++ b/rightscript.go
@@ -47,8 +47,8 @@ type RightScript struct {
 
 var (
 	lineage                = regexp.MustCompile(`/api/acct/(\d+)/right_scripts/.+$`)
-	powershellAssignment   = regexp.MustCompile(`(?i)^\s*\$[a-z0-9_:]+\s*=`)
-	powershellWriteCmdlets = regexp.MustCompile(`(?i)^\s*Write-(?:Debug|Error|EventLog|Host|Information|Output|Progress|Verbose|Warning)`)
+	powershellAssignment   = regexp.MustCompile(`(?im)^\s*\$[a-z0-9_:]+\s*=`)
+	powershellWriteCmdlets = regexp.MustCompile(`(?im)^\s*Write-(?:Debug|Error|EventLog|Host|Information|Output|Progress|Verbose|Warning)`)
 )
 
 func rightScriptShow(href string) {

--- a/rightscript_test.go
+++ b/rightscript_test.go
@@ -18,7 +18,7 @@ var _ = Describe("RightScript", func() {
 		Entry("perl shebang", "#!/usr/bin/perl\nprint \"Hello, world!\\n\"\n", ".pl"),
 		Entry("bash shebang", "#!/bin/bash\necho 'Hello, world!'\n", ".sh"),
 		Entry("PowerShell shebang", "#!PowerShell\necho 'Hello, world!'\n", ".ps1"),
-		Entry("PowerShell assignment", "$env:HELLO_WORLD = 'Hello, world!'\necho $env:HELLO_WORLD\n", ".ps1"),
-		Entry("PowerShell Write Cmdlets", "Write-Host 'Hello, world!'\n", ".ps1"),
+		Entry("PowerShell assignment", "# hello.ps1\n$env:HELLO_WORLD = 'Hello, world!'\necho $env:HELLO_WORLD\n", ".ps1"),
+		Entry("PowerShell Write Cmdlets", "# hello.ps1\nWrite-Host 'Hello, world!'\n", ".ps1"),
 	)
 })

--- a/rightscript_test.go
+++ b/rightscript_test.go
@@ -1,0 +1,24 @@
+package main_test
+
+import (
+	. "github.com/rightscale/right_st"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RightScript", func() {
+	DescribeTable("GuessExtension",
+		func(source, extension string) {
+			Expect(GuessExtension(source)).To(Equal(extension))
+		},
+		Entry("no shebang", "echo 'Hello, world!'\n", ""),
+		Entry("ruby shebang", "#!/usr/bin/ruby\nputs 'Hello, world!'\n", ".rb"),
+		Entry("perl shebang", "#!/usr/bin/perl\nprint \"Hello, world!\\n\"\n", ".pl"),
+		Entry("bash shebang", "#!/bin/bash\necho 'Hello, world!'\n", ".sh"),
+		Entry("PowerShell shebang", "#!PowerShell\necho 'Hello, world!'\n", ".ps1"),
+		Entry("PowerShell assignment", "$env:HELLO_WORLD = 'Hello, world!'\necho $env:HELLO_WORLD\n", ".ps1"),
+		Entry("PowerShell Write Cmdlets", "Write-Host 'Hello, world!'\n", ".ps1"),
+	)
+})


### PR DESCRIPTION
Add file extension guessing for PowerShell RightScript download using either a shebang or some heuristics. Let's leave this PR open for a bit to see if we can come up with any more useful heuristics.