### PR TITLE
Apparently viper likes lower case only (fixes #44)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+v1.6.3 / 2017-08-03
+-------------------
+* Work around a bug with account selection due to [viper]'s case-insensitivity.
+
+[viper]: https://github.com/spf13/viper
+
 v1.6.2 / 2017-07-27
 -------------------
 * Add missing -m and -p short options to the `right_st st download` subcommand,

--- a/config.go
+++ b/config.go
@@ -79,12 +79,12 @@ func ReadConfig(configFile, account string) error {
 		var ok bool
 		if account == "" {
 			defaultAccount := Config.GetString("login.default_account")
-			Config.Account, ok = Config.Accounts[defaultAccount]
+			Config.Account, ok = Config.Accounts[strings.ToLower(defaultAccount)]
 			if !ok {
 				return fmt.Errorf("%s: could not find default account: %s", configFile, defaultAccount)
 			}
 		} else {
-			Config.Account, ok = Config.Accounts[account]
+			Config.Account, ok = Config.Accounts[strings.ToLower(account)]
 			if !ok {
 				return fmt.Errorf("%s: could not find account: %s", configFile, account)
 			}


### PR DESCRIPTION
* Work around a bug with account selection due to [viper]'s case-insensitivity.

[viper]: https://github.com/spf13/viper